### PR TITLE
Fixed generation of constant variable names

### DIFF
--- a/tools/vendure-nx/src/generators/files/src/lib/constants.ts.template
+++ b/tools/vendure-nx/src/generators/files/src/lib/constants.ts.template
@@ -1,2 +1,2 @@
 export const loggerCtx = '<%= titlecase(name) %>Plugin';
-export const <%= uppercase(filename) %>_PLUGIN_OPTIONS = Symbol('<%= uppercase(filename) %>_PLUGIN_OPTIONS');
+export const <%= constantcase(name) %>_PLUGIN_OPTIONS = Symbol('<%= constantcase(name) %>_PLUGIN_OPTIONS');

--- a/tools/vendure-nx/src/generators/files/src/ui/index.ts.template
+++ b/tools/vendure-nx/src/generators/files/src/ui/index.ts.template
@@ -3,7 +3,7 @@ import path from 'path';
 
 export const uiExtensions: AdminUiExtension = {
     id: '<%= filename %>',
-    extensionPath: path.join(process.cwd(), 'libs/<%= filename %>-plugin/src/ui'),
+    extensionPath: path.join(process.cwd(), 'libs/plugin-<%= filename %>/src/ui'),
     providers: ['providers.ts'],
     routes: [{ route: '<%= filename %>', filePath: 'routes.ts' }],
 };

--- a/tools/vendure-nx/src/generators/vendure-plugin-generator.ts
+++ b/tools/vendure-nx/src/generators/vendure-plugin-generator.ts
@@ -19,6 +19,17 @@ function uppercase(val: string) {
 
 /**
  * @description
+ * Convert a string to UPPERCASE with underscore separator.
+ * @param val
+ */
+function constantcase(val: string) {
+  return val.replace(/(?:^|\.?)([A-Z])/g, (x, y) => '_' + y)
+    .replace(/^_/, '')
+    .toUpperCase();
+}
+
+/**
+ * @description
  * Convert a string to TitleCase.
  * @param val
  */
@@ -84,6 +95,7 @@ export async function vendurePluginGenerator(
     uppercase,
     titlecase,
     kebabcase,
+    constantcase,
     filename: kebabcase(options.name),
     ...options,
   });


### PR DESCRIPTION
I discovered that the generated variable name for was off

```diff
- export const OPEN-AI_PLUGIN_OPTIONS = Symbol('OPEN-AI_PLUGIN_OPTIONS');
+ export const OPEN_AI_PLUGIN_OPTIONS = Symbol('OPEN_AI_PLUGIN_OPTIONS');
```